### PR TITLE
LDC: Add -boundscheck=off -singleobj

### DIFF
--- a/framework/lang_d.py
+++ b/framework/lang_d.py
@@ -42,6 +42,8 @@ def build_d_sources_with_ldc(source_dir, output_dir, compiler_executable):
         '-O3',
         '-m64',
         '-release',
+        '-boundscheck=off',
+        '-singleobj',
         '-od' + output_dir,
         '-of' + os.path.join(output_dir, common.EXECUTABLE_NAME),
         '-I' + os.path.join(common.COMMON_DIR_PATH, 'lang_d')


### PR DESCRIPTION
The other two D compilers already had bounds checking disabled.

-singleobj leads to better optimization potential in the "all-at-once"
compilation model, as the compiler is not forced to create separate
object files for each source file (it's the default when using the ldmd2
driver).
